### PR TITLE
Switching to conda for OPS install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ install:
 
 script:
     - conda install --yes conda-build
+    - conda config --set always_yes true
     # when OPS conda doesn't work, use the next lines
-    #- conda config --set always_yes true
     #- source devtools/no-ops-conda/make_build.sh
     #- source devtools/no-ops-conda/build.sh
     # when OPS conda works, use the line below
+    - conda build devtools/conda-recipe
     - conda install --yes --use-local dynamiq_samplers-dev
-    - conda install --yes openpathsampling
     - conda install --yes nose python-coveralls
 
     # other packages are built in the build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
     - export PYTHONUNBUFFERED=true
 
 script:
+    - conda install --yes conda-build
     # when OPS conda doesn't work, use the next lines
-    #- conda install --yes conda-build
     #- conda config --set always_yes true
     #- source devtools/no-ops-conda/make_build.sh
     #- source devtools/no-ops-conda/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
     # when OPS conda works, use the line below
     - conda install --yes --name test --use-local dynamiq_samplers-dev
     - source activate test
+    - conda install --yes openpathsampling
     - conda install --yes nose python-coveralls
 
     # other packages are built in the build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,16 @@ install:
     - export PYTHONUNBUFFERED=true
 
 script:
-    - conda install --yes conda-build
-    - conda config --set always_yes true
-    # when OPS conda doesn't work, use the next 2 lines
+    # when OPS conda doesn't work, use the next lines
+    #- conda install --yes conda-build
+    #- conda config --set always_yes true
     #- source devtools/no-ops-conda/make_build.sh
     #- source devtools/no-ops-conda/build.sh
     # when OPS conda works, use the line below
-    - conda build devtools/conda-recipe
-    #- source activate _test
+    - conda install --yes --name test --use-local dynamiq_samplers-dev
+    - source activate test
+    - conda install --yes nose python-coveralls
+
     # other packages are built in the build.sh
     - nosetests -v --with-coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ script:
     #- source devtools/no-ops-conda/make_build.sh
     #- source devtools/no-ops-conda/build.sh
     # when OPS conda works, use the line below
-    - conda install --yes --name test --use-local dynamiq_samplers-dev
-    - source activate test
+    - conda install --yes --use-local dynamiq_samplers-dev
     - conda install --yes openpathsampling
     - conda install --yes nose python-coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ script:
     - conda install --yes conda-build
     - conda config --set always_yes true
     # when OPS conda doesn't work, use the next 2 lines
-    - source devtools/no-ops-conda/make_build.sh
-    - source devtools/no-ops-conda/build.sh
+    #- source devtools/no-ops-conda/make_build.sh
+    #- source devtools/no-ops-conda/build.sh
     # when OPS conda works, use the line below
-    #- conda build devtools/conda-recipe
+    - conda build devtools/conda-recipe
     #- source activate _test
     # other packages are built in the build.sh
     - nosetests -v --with-coverage

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
         - numpy
         - scipy
         - pandas
-        - openpathsampling-dev
+        - openpathsampling
 
 
 test:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,9 +20,5 @@ requirements:
 
 
 test:
-    requires:
-        - nose
-        - python-coveralls
-
     imports:
         - dynamiq_samplers


### PR DESCRIPTION
Now that OPS should be conda-available (as long as conda is up), we switch to the conda build of OPS. This means we work on the latest OPS release, instead of working on dev.
